### PR TITLE
Youtube support

### DIFF
--- a/src/js/hxelper-functions.js
+++ b/src/js/hxelper-functions.js
@@ -112,6 +112,7 @@
     $$.publishEvent = function(eventName, instanceID, list) {
         // console.log(eventName, list);
         if (!$$.exists(instanceID) || instanceID === "") {
+            // WARNING: If events aren't properly sent/received, check pub/sub functions are encoding object id in base64
             jQuery.each($$._instanceIDs, function(_, inst_id) {  
                 // some of the events require the core to handle calling the components in a certain order
                 if ($$.requiredEvents.indexOf(eventName) >= 0) {

--- a/src/js/hxighlighter.js
+++ b/src/js/hxighlighter.js
@@ -25,6 +25,7 @@ root.Hxighlighter = root.Hxighlighter || function(options) {
         if (Hxighlighter.exists(options.commonInfo.context_id) &&
             Hxighlighter.exists(options.commonInfo.collection_id) &&
             Hxighlighter.exists(options.commonInfo.object_id)) {
+            // WARNING: If events aren't properly sent/received, check pub/sub functions are encoding object id in base64
             inst_id = options.commonInfo.context_id.replace(/\+/g, '_') + ':' + options.commonInfo.collection_id + ':' + btoa(options.commonInfo.object_id)
         } else {
             inst_id = Hxighlighter.getUniqueId();

--- a/src/js/hxighlighter.js
+++ b/src/js/hxighlighter.js
@@ -25,7 +25,7 @@ root.Hxighlighter = root.Hxighlighter || function(options) {
         if (Hxighlighter.exists(options.commonInfo.context_id) &&
             Hxighlighter.exists(options.commonInfo.collection_id) &&
             Hxighlighter.exists(options.commonInfo.object_id)) {
-            inst_id = options.commonInfo.context_id.replace(/\+/g, '_') + ':' + options.commonInfo.collection_id + ':' + options.commonInfo.object_id
+            inst_id = options.commonInfo.context_id.replace(/\+/g, '_') + ':' + options.commonInfo.collection_id + ':' + btoa(options.commonInfo.object_id)
         } else {
             inst_id = Hxighlighter.getUniqueId();
         }

--- a/src/js/plugins/rangeslider.js
+++ b/src/js/plugins/rangeslider.js
@@ -18,10 +18,9 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-import * as videojs from 'video.js/dist/video.js'
-console.log(videojs);
 //----------------Load Plugin----------------//
 (function (){
+	var videojs = require('video.js');
 //-- Load RangeSlider plugin in videojs
 function RangeSlider_(options){
 	var player = this;

--- a/src/js/plugins/vjs-annotation-display-component.js
+++ b/src/js/plugins/vjs-annotation-display-component.js
@@ -3,9 +3,9 @@
  * code that can be found in `videojs-annotator-plugin.js`
  */
 
-import * as videojs from 'video.js/dist/video.js'
-
 (function($) {
+    var videojs = require('video.js');
+
     // Get the Component base class from Video.js
     var Component = videojs.getComponent('Component');
 

--- a/src/js/plugins/vjs-live-transcript.js
+++ b/src/js/plugins/vjs-live-transcript.js
@@ -1,6 +1,6 @@
-import * as videojs from 'video.js/dist/video.js'
-
 (function($) {
+  var videojs = require('video.js');
+
   // Get the Component base class from Video.js
   var Component = videojs.getComponent('Component');
 

--- a/src/js/plugins/vjs-rangeslider-component.js
+++ b/src/js/plugins/vjs-rangeslider-component.js
@@ -1,7 +1,6 @@
-
-import * as videojs from 'video.js/dist/video.js'
-
 (function($) {
+  var videojs = require('video.js');
+
   // Get the Component base class from Video.js
   var Component = videojs.getComponent('Component');
 

--- a/src/js/videoVJStargetcontroller.js
+++ b/src/js/videoVJStargetcontroller.js
@@ -20,11 +20,13 @@ require('./plugins/vjs-rangeslider-component.js');
 
 require('./storage/catchpy.js');
 
-import * as videojs from 'video.js/dist/video.js';
-import 'videojs-transcript-ac/dist/videojs-transcript.js';
-import 'videojs-youtube/dist/Youtube.js';
+require('video.js');
+require('videojs-transcript');
+require('videojs-youtube');
 
 (function($) {
+    var videojs = require('video.js');
+
     /**
      * { function_description }
      *

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,8 @@ module.exports = {
             "$": require.resolve('jquery'),
             'jQuery': require.resolve('jquery'),
             _: require.resolve('lodash'),
-            'toastr': require.resolve('toastr')
+            'toastr': require.resolve('toastr'),
+            "videojs": require.resolve('video.js')
         }),
         new MiniCssExtractPlugin({
             filename: 'dist/hxighlighter_[name].css',
@@ -51,12 +52,17 @@ module.exports = {
     },
     resolve: {
         extensions: ['.js'],
+        // Note: mainFields prioritizes the "main" entrypoint to deal with a video.js conflict 
+        //       between video.es.js and video.cjs.js
+        mainFields: ['main', 'module'], 
         alias: {
             'annotator': PATHS.vendor + 'Annotator/annotator.ui.js',
             'CodeMirror': 'codemirror',
             'jquery-tokeninput': PATHS.modules + 'jquery.tokeninput/',
             'handlebars': PATHS.modules + 'handlebars/dist/handlebars.min.js',
-            'videojs': PATHS.modules + 'video.js/dist/video.js'
+            'videojs': PATHS.modules + 'video.js',
+            'videojs-transcript': PATHS.modules + 'videojs-transcript-ac/dist/videojs-transcript.js',
+            'videojs-youtube': PATHS.modules + 'videojs-youtube/dist/Youtube.js'
         }
     },
     optimization: {


### PR DESCRIPTION
This PR attempts to get youtube videos working again with the new video annotation UI by resolving a few small issues.

Changes:
- Modified the `instance_id` in the Hxighlighter core to ensure it works as expected with the jQuery event system. It seems that some `object_id` values (e.g. video URLs), cause problems due to certain characters in the URL. For your average mp4 video, it works fine, but for youtube videos with query parameters, it doesn't. Converting the `object_id` to base64 resolves this issue.
- Updated all `video.js` imports so they consistently use the CJS version. Prior to this change, it seems that multiple versions of the videojs module were being included in the webpack build (e.g. `dist/video.js`, `video.es.js`, and `video.cjs.js`). The youtube plugin was only getting registered with one of them (the wrong one, it seems). 

In addition to these changes, there's one small change that we need to make to the [HxAT](https://github.com/lduarte1991/hxat/blob/ef759e440327cec5e834c28b7207ffd4540ef19b/hx_lti_initializer/templates/vd/detail_hxighlighter.html#L134) to ensure that the correct `source_type` is passed to Hxighlighter depending on the video URL (e.g. `video/mp4` or `video/youtube`).

@lduarte1991 Thoughts?