### PR TITLE
2026-04-23 [v1.9.1] Fix build banner, resolve npm vulnerabilities, update to Node 22 LTS

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hxighlighter",
-  "version": "1.8.1",
+  "version": "1.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hxighlighter",
-      "version": "1.8.1",
+      "version": "1.9.1",
       "license": "UNLICENSED",
       "dependencies": {
         "codemirror": "^6.0.2",
@@ -52,7 +52,7 @@
         "webpack-cli": "^7.0.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@babel/cli": {
@@ -143,7 +143,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2885,7 +2884,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2934,7 +2932,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3446,7 +3443,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4030,16 +4026,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/css-minimizer-webpack-plugin/node_modules/serialize-javascript": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
-      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -4280,13 +4266,12 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4606,7 +4591,6 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5664,7 +5648,6 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
       "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -8018,7 +8001,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8780,15 +8762,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -9009,13 +8982,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/shallow-clone": {
@@ -9909,7 +9882,6 @@
       "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.23.8.tgz",
       "integrity": "sha512-plZuWxN4clhDESSpi3QLYVs6tgnnf9qT9SA4iahHwZEmdVSuUh4+O6vQPcA5XqiEDvjeBDJvLafH1bhkAXaXKQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@videojs/http-streaming": "^3.17.4",
@@ -10005,7 +9977,6 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -10471,7 +10442,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -12334,8 +12304,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-import-phases": {
       "version": "1.0.4",
@@ -12367,7 +12336,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12686,7 +12654,6 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -13043,12 +13010,6 @@
             "merge-stream": "^2.0.0",
             "supports-color": "^8.1.1"
           }
-        },
-        "serialize-javascript": {
-          "version": "7.0.5",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
-          "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
-          "dev": true
         }
       }
     },
@@ -13219,13 +13180,12 @@
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true
     },
     "dom-serializer": {
@@ -13445,7 +13405,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -14144,7 +14103,6 @@
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
       "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
-      "peer": true,
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -15134,7 +15092,7 @@
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
         "debug": "^4.3.5",
-        "diff": "^7.0.0",
+        "diff": ">=8.0.3",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^10.4.5",
@@ -15145,7 +15103,7 @@
         "minimatch": "^9.0.5",
         "ms": "^2.1.3",
         "picocolors": "^1.1.1",
-        "serialize-javascript": "^6.0.2",
+        "serialize-javascript": ">=7.0.5",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
         "workerpool": "^9.2.0",
@@ -15756,7 +15714,6 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
       "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
       "dev": true,
-      "peer": true,
       "requires": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16226,15 +16183,6 @@
         "side-channel": "^1.1.0"
       }
     },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -16392,13 +16340,10 @@
       "dev": true
     },
     "serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "dev": true
     },
     "shallow-clone": {
       "version": "3.0.1",
@@ -17004,7 +16949,6 @@
       "version": "8.23.8",
       "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.23.8.tgz",
       "integrity": "sha512-plZuWxN4clhDESSpi3QLYVs6tgnnf9qT9SA4iahHwZEmdVSuUh4+O6vQPcA5XqiEDvjeBDJvLafH1bhkAXaXKQ==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.28.4",
         "@videojs/http-streaming": "^3.17.4",
@@ -17080,7 +17024,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hxighlighter",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "JavaScript annotation tool suite",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "private": true,
   "engines": {
-    "node": ">=20"
+    "node": ">=22.13.0"
   },
   "browserslist": [
     "> 0.5%",
@@ -76,5 +76,11 @@
     "underscore-template-loader": "^1.2.0",
     "webpack": "^5.105.4",
     "webpack-cli": "^7.0.2"
+  },
+  "overrides": {
+    "mocha": {
+      "diff": ">=8.0.3",
+      "serialize-javascript": ">=7.0.5"
+    }
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,146 +3,146 @@ const webpack = require('webpack');
 
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
+const TerserPlugin = require('terser-webpack-plugin');
 const { version } = require('./package.json');
 
 const PATHS = {
-    vendor: path.join(__dirname, 'src/js/vendors/'),
-    modules: path.join(__dirname, 'node_modules/')
-}
+  vendor: path.join(__dirname, 'src/js/vendors/'),
+  modules: path.join(__dirname, 'node_modules/')
+};
 
 module.exports = {
-    entry: {
-        text: ['./src/text-index.js'],
-        text_lite: ['./src/author-index.js'],
-        image_m2: ['./src/image-index-m2.js'],
-        video_vjs: ['./src/video-index-vjs.js']
-    },
-    plugins: [
-        new webpack.ProvidePlugin({
-            "jquery": require.resolve('jquery'),
-            "$": require.resolve('jquery'),
-            'jQuery': require.resolve('jquery'),
-            'toastr': require.resolve('toastr'),
-            "videojs": require.resolve('video.js')
-        }),
-        new MiniCssExtractPlugin({
-            filename: 'dist/hxighlighter_[name].css',
-            chunkFilename: "[id].css"
-        }),
-        new webpack.DefinePlugin({
-          'require.specified': 'require.resolve'
-        }),
-        new webpack.IgnorePlugin({
-            resourceRegExp: /^codemirror$/
-        }),
-        new webpack.BannerPlugin({
-            banner: `Version: ${version} - ${new Date().toLocaleString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit', second: '2-digit' })}`,
-        }),
+  entry: {
+    text: ['./src/text-index.js'],
+    text_lite: ['./src/author-index.js'],
+    image_m2: ['./src/image-index-m2.js'],
+    video_vjs: ['./src/video-index-vjs.js']
+  },
+  plugins: [
+    new webpack.ProvidePlugin({
+      "jquery": require.resolve('jquery'),
+      "$": require.resolve('jquery'),
+      'jQuery': require.resolve('jquery'),
+      'toastr': require.resolve('toastr'),
+      "videojs": require.resolve('video.js')
+    }),
+    new MiniCssExtractPlugin({
+      filename: 'dist/hxighlighter_[name].css',
+      chunkFilename: "[id].css"
+    }),
+    new webpack.DefinePlugin({
+      'require.specified': 'require.resolve'
+    }),
+    new webpack.IgnorePlugin({
+      resourceRegExp: /^codemirror$/
+    }),
+    new webpack.BannerPlugin({
+      banner: `Version: ${version} - ${new Date().toLocaleString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit', second: '2-digit' })}`,
+    }),
+  ],
+  output: {
+    path: __dirname,
+    filename: 'dist/hxighlighter_[name].js',
+    assetModuleFilename: '[hash][ext][query]'
+  },
+  resolve: {
+    extensions: ['.js'],
+    // Note: mainFields prioritizes the "main" entrypoint to deal with a video.js conflict
+    //       between video.es.js and video.cjs.js
+    mainFields: ['main', 'module'],
+    alias: {
+      'jquery': path.resolve(__dirname, 'node_modules/jquery/dist/jquery.js'),
+      'annotator': PATHS.vendor + 'Annotator/annotator.ui.js',
+      'jQuery': 'jquery',
+      'CodeMirror': 'codemirror',
+      'jquery-tokeninput': PATHS.modules + 'jquery.tokeninput/',
+      'handlebars': PATHS.modules + 'handlebars/dist/handlebars.min.js',
+      'videojs': PATHS.modules + 'video.js',
+      'videojs-transcript': PATHS.modules + 'videojs-transcript-ac/dist/videojs-transcript.js',
+      'videojs-youtube': PATHS.modules + 'videojs-youtube/dist/Youtube.js'
+    }
+  },
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new TerserPlugin({ extractComments: false }),
+      new CssMinimizerPlugin(),
     ],
-    output: {
-        path: __dirname,
-        filename: 'dist/hxighlighter_[name].js',
-        assetModuleFilename: '[hash][ext][query]'
-    },
-    resolve: {
-        extensions: ['.js'],
-        // Note: mainFields prioritizes the "main" entrypoint to deal with a video.js conflict 
-        //       between video.es.js and video.cjs.js
-        mainFields: ['main', 'module'], 
-        alias: {
-            'jquery': path.resolve(__dirname, 'node_modules/jquery/dist/jquery.js'),
-            'annotator': PATHS.vendor + 'Annotator/annotator.ui.js',
-            'jQuery': 'jquery',
-            'CodeMirror': 'codemirror',
-            'jquery-tokeninput': PATHS.modules + 'jquery.tokeninput/',
-            'handlebars': PATHS.modules + 'handlebars/dist/handlebars.min.js',
-            'videojs': PATHS.modules + 'video.js',
-            'videojs-transcript': PATHS.modules + 'videojs-transcript-ac/dist/videojs-transcript.js',
-            'videojs-youtube': PATHS.modules + 'videojs-youtube/dist/Youtube.js'
-        }
-    },
-    optimization: {
-        minimize: true,
-        minimizer: [
-            // For webpack@5 you can use the `...` syntax to extend existing minimizers (i.e. `terser-webpack-plugin`), uncomment the next line
-            `...`,
-            new CssMinimizerPlugin(),
-          ],
-    },
-    externals: {
-        'Mirador': 'Mirador'
-    },
-    module: {
-        rules: [
-            {
-                test: /\.css$/,
-                use: [
-                    {
-                        loader: MiniCssExtractPlugin.loader,
-                        options: {
-                            publicPath: '../',
-                        }
-                    },
-                    "css-loader"
-                ]
-            },
-            {
-                test: /\.(eot|ttf|woff(2)?)(\?v=\d+\.\d+\.\d+)?/,
-                type: 'asset/inline'
-            }, 
-            {
-                test: /\.(gif|svg|png|jpg)(\?v=\d+\.\d+\.\d+)?/,
-                type: 'asset/inline'
-            },
-            {
-                test: /annotator\.ui\.js/,
-                use: [{
-                    loader: "imports-loader",
-                    options: {
-                        imports: [
-                            "defaults jquery $",
-                            "defaults jquery window.jQuery",
-                            "defaults jquery jQuery"
-                        ]
-                    }
-                }]
-            },
-            // {
-            //     test: /mirador\.js/,
-            //     use: 'script-loader'
-            // },
-            {
-                test: /videojs-transcript.js/,
-                use: [{
-                    loader: "imports-loader",
-                    options: {
-                        imports: [
-                            "defaults videojs videojs"
-                        ]
-                    }
-                }]
-            },
-            {
-                test: /(floating|sidebar)\.html$/,
-                use: ['underscore-template-loader']
-            },
-            { test: /\.handlebars$/, loader: "handlebars-loader" },
-            {
-                test: /\.js$/,
-                exclude: /node_modules/,
-                use: {
-                    loader: 'babel-loader',
-                    options: {
-                        presets: ['@babel/preset-env']
-                    }
-                }
+  },
+  externals: {
+    'Mirador': 'Mirador'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              publicPath: '../',
             }
+          },
+          "css-loader"
         ]
-    },
-    performance: {
-        'hints': false
-    },
-    ignoreWarnings: [
-        /Failed to parse source map.*summernote/,
+      },
+      {
+        test: /\.(eot|ttf|woff(2)?)(\?v=\d+\.\d+\.\d+)?/,
+        type: 'asset/inline'
+      },
+      {
+        test: /\.(gif|svg|png|jpg)(\?v=\d+\.\d+\.\d+)?/,
+        type: 'asset/inline'
+      },
+      {
+        test: /annotator\.ui\.js/,
+        use: [{
+          loader: "imports-loader",
+          options: {
+            imports: [
+              "defaults jquery $",
+              "defaults jquery window.jQuery",
+              "defaults jquery jQuery"
+            ]
+          }
+        }]
+      },
+      // {
+      //     test: /mirador\.js/,
+      //     use: 'script-loader'
+      // },
+      {
+        test: /videojs-transcript.js/,
+        use: [{
+          loader: "imports-loader",
+          options: {
+            imports: [
+              "defaults videojs videojs"
+            ]
+          }
+        }]
+      },
+      {
+        test: /(floating|sidebar)\.html$/,
+        use: ['underscore-template-loader']
+      },
+      { test: /\.handlebars$/, loader: "handlebars-loader" },
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env']
+          }
+        }
+      }
     ]
-}
+  },
+  performance: {
+    'hints': false
+  },
+  ignoreWarnings: [
+    /Failed to parse source map.*summernote/,
+  ]
+};


### PR DESCRIPTION
This PR addresses three issues with the build and CI setup:

### Build banner fix
- Added explicit `TerserPlugin` with `extractComments: false` to prevent Webpack 5's Terser from extracting the version/date banner to `.LICENSE.txt` sidecar files. The `BannerPlugin` comment now stays inline as the first line of each dist JS file.

### npm audit vulnerabilities (3 → 0)
- Added `overrides` in package.json to pin mocha's transitive dependencies to patched versions:
  - `diff` ≥8.0.3 — fixes DoS in `parsePatch`/`applyPatch` ([GHSA-73rr-hh4g-fpgx](https://github.com/advisories/GHSA-73rr-hh4g-fpgx))
  - `serialize-javascript` ≥7.0.5 — fixes RCE via `RegExp.flags` ([GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq)) and CPU exhaustion DoS ([GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v))

### Node 22 LTS
- Updated `engines.node` from `>=20` to `>=22.13.0` to match ESLint 10.x requirements and eliminate EBADENGINE warnings
- Updated CI workflow to `node-version: 22`

### Formatting
- Reformatted webpack.config.js to consistent 2-space indentation (no functional changes)
- Version bump to 1.9.1

**Files changed:** package.json, package-lock.json, webpack.config.js, lint.yml