### PR TITLE
Hx 555 hxighlighter dist files can no longer be uploaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.10.2] - 2026-07-30
+
+### Fixed
+
+- [HX-507] Refactored `h-range.js` to simplify range-handling logic and fix related bugs
+- [HX-503] Additional bug fixes in `h-range.js` identified via code review
+- WAF 403 on dist uploads: replaced `data:` URI download anchors in `hx-lite-version-changes.js` and `hx-export-print.js` with `Blob` + `URL.createObjectURL`
+- WAF 403 on dist uploads: disabled CSS minification (`CssMinimizerPlugin` removed) and added Terser `max_line_len` cap to keep built files below WAF scoring threshold
+
+### Changed
+
+- Updated inline documentation and JSDoc comments throughout `h-range.js`
+
+### Tests
+
+- Added unit tests for `h-range.js` (HX-507)
+- Enhanced `TempJSON.js` unit test coverage
+
+### Dependencies
+
+- Bump webpack 5.107.2 → 5.108.4
+- Bump webpack-cli 7.0.3 → 7.2.1
+- Bump eslint 10.5.0 → 10.6.0
+- Bump globals 17.6.0 → 17.7.0
+- Bump video.js 8.23.8 → 8.23.9
+- Bump npm-check-updates 22.2.3 → 22.2.9
+
+## [1.10.1] - 2026-06-27
+
+Baseline release. See git history for details.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hxighlighter",
-  "version": "1.10.0",
+  "version": "1.10.2",
   "description": "JavaScript annotation tool suite",
   "main": "index.js",
   "scripts": {

--- a/src/js/plugins/hx-export-print.js
+++ b/src/js/plugins/hx-export-print.js
@@ -114,13 +114,16 @@
   };
 
   $.ExportPlugin.prototype.download = function(filename, text) {
+    var blob = new Blob([text], { type: 'text/plain' });
+    var objectUrl = URL.createObjectURL(blob);
     var element = document.createElement('a');
-    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+    element.setAttribute('href', objectUrl);
     element.setAttribute('download', filename);
     element.style.display = 'none';
     document.body.appendChild(element);
     element.click();
     document.body.removeChild(element);
+    URL.revokeObjectURL(objectUrl);
   };
 
   $.ExportPlugin.prototype.filterByWhose = function(annotations, whose) {

--- a/src/js/plugins/hx-lite-version-changes.js
+++ b/src/js/plugins/hx-lite-version-changes.js
@@ -38,13 +38,15 @@
           var annotationList = {
             rows: list
           };
-          var new_page = 'data:application/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(annotationList, null, 4));
+          var blob = new Blob([JSON.stringify(annotationList, null, 4)], { type: 'application/json' });
+          var objectUrl = URL.createObjectURL(blob);
           var downloadAnchorNode = document.createElement('a');
-          downloadAnchorNode.setAttribute("href",     new_page);
+          downloadAnchorNode.setAttribute("href", objectUrl);
           downloadAnchorNode.setAttribute("download", "annotations.json");
           document.body.appendChild(downloadAnchorNode); // required for firefox
           downloadAnchorNode.click();
           downloadAnchorNode.remove();
+          URL.revokeObjectURL(objectUrl);
         };
         $.publishEvent('downloadAnnotations', self.instanceID, [downloadFun]);
       });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,6 @@ const path = require('path');
 const webpack = require('webpack');
 
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 const TerserPlugin = require('terser-webpack-plugin');
 const { version } = require('./package.json');
 
@@ -65,8 +64,13 @@ module.exports = {
   optimization: {
     minimize: true,
     minimizer: [
-      new TerserPlugin({ extractComments: false }),
-      new CssMinimizerPlugin(),
+      new TerserPlugin({
+        extractComments: false,
+        terserOptions: {
+          format: { max_line_len: 32000 },
+        },
+      }),
+      // CssMinimizerPlugin omitted — CSS stays unminified to pass WAF
     ],
   },
   externals: {


### PR DESCRIPTION
Uploading built dist/ bundles to the platform was returning 403 errors from the WAF. Binary search identified two triggers:

1. data: URI download links — hx-lite-version-changes.js and hx-export-print.js both constructed download anchors by encoding file content directly into data:application/json and data:text/plain href strings. These are replaced with Blob + URL.createObjectURL (with revokeObjectURL cleanup), which produces an opaque blob: URL instead of an inline data payload. JS bundles now pass WAF.

2. CSS minification — The CSS bundles also triggered the WAF because CssMinimizerPlugin was compressing the annotator vendor CSS (which contains base64-inlined PNGs) into dense lines with concentrated data:image/png;base64 hits. CssMinimizerPlugin has been removed from the webpack optimization.minimizer array — CSS is left unminified, which was already confirmed to pass WAF. TerserPlugin gains a max_line_len: 32000 option to keep JS lines well under any WAF line-length thresholds.

Files changed:

src/js/plugins/hx-lite-version-changes.js — Blob download for JSON export
src/js/plugins/hx-export-print.js — Blob download for text export
webpack.config.js — Remove CssMinimizerPlugin, add Terser max_line_len