### PR TITLE
[HX-556] missing package json item causes v1.10.2 release failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.3] - 2026-08-04
+
+### Fixed
+
+- Add missing `terser-webpack-plugin` devDependency that caused the v1.10.2 release build to fail
+
 ## [1.10.2] - 2026-07-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [1.10.3] - 2026-08-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hxighlighter",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "JavaScript annotation tool suite",
   "main": "index.js",
   "scripts": {
@@ -77,6 +77,7 @@
     "npm-run-all2": "^9.0.2",
     "puppeteer": "^25.3.0",
     "sinon": "^22.1.0",
+    "terser-webpack-plugin": "^5.3.0",
     "style-loader": "^4.0.0",
     "underscore-template-loader": "^1.2.0",
     "webpack": "^5.108.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       style-loader:
         specifier: ^4.0.0
         version: 4.0.0(webpack@5.108.4)
+      terser-webpack-plugin:
+        specifier: ^5.3.0
+        version: 5.6.1(postcss@8.5.15)(webpack@5.108.4)
       underscore-template-loader:
         specifier: ^1.2.0
         version: 1.2.0
@@ -3113,6 +3116,49 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  terser-webpack-plugin@5.6.1:
+    resolution: {integrity: sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@minify-html/node': '*'
+      '@swc/core': '*'
+      '@swc/css': '*'
+      '@swc/html': '*'
+      clean-css: '*'
+      cssnano: '*'
+      csso: '*'
+      esbuild: '*'
+      html-minifier-terser: '*'
+      lightningcss: '*'
+      postcss: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@minify-html/node':
+        optional: true
+      '@swc/core':
+        optional: true
+      '@swc/css':
+        optional: true
+      '@swc/html':
+        optional: true
+      clean-css:
+        optional: true
+      cssnano:
+        optional: true
+      csso:
+        optional: true
+      esbuild:
+        optional: true
+      html-minifier-terser:
+        optional: true
+      lightningcss:
+        optional: true
+      postcss:
+        optional: true
+      uglify-js:
+        optional: true
 
   terser@5.48.0:
     resolution: {integrity: sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==}
@@ -6761,6 +6807,16 @@ snapshots:
   symbol-tree@3.2.4: {}
 
   tapable@2.3.3: {}
+
+  terser-webpack-plugin@5.6.1(postcss@8.5.15)(webpack@5.108.4):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.48.0
+      webpack: 5.108.4(postcss@8.5.15)(webpack-cli@7.2.1)
+    optionalDependencies:
+      postcss: 8.5.15
 
   terser@5.48.0:
     dependencies:


### PR DESCRIPTION
**Fix v1.10.2 release failure — bump to v1.10.3**

The v1.10.2 release CI failed because terser-webpack-plugin was used by the webpack build but was never listed as a devDependency in package.json. The pnpm install --frozen-lockfile step in the release workflow exited cleanly, but the dependency was effectively undeclared.

Changes:
* Add terser-webpack-plugin ^5.3.0 to devDependencies in package.json
* Bump version 1.10.2 → 1.10.3
* Update pnpm-lock.yaml to reflect the added dependency
* Add [1.10.3] entry to CHANGELOG.md